### PR TITLE
[Feature] home 예외 처리

### DIFF
--- a/app/src/main/java/com/linkedlist/linkllet/navigation/LnkNavHost.kt
+++ b/app/src/main/java/com/linkedlist/linkllet/navigation/LnkNavHost.kt
@@ -33,6 +33,7 @@ fun LnkNavHost(
             navigateToLinks = { id, title ->
                 navController.navigateToLinks(folderId = id,title = title )
             },
+            onShowSnackbar = onShowSnackbar
         )
         AddEditLink(
             onBack = {

--- a/core/data/src/main/java/com/linkedlist/linkellet/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/linkedlist/linkellet/core/data/repository/AuthRepositoryImpl.kt
@@ -1,7 +1,5 @@
 package com.linkedlist.linkellet.core.data.repository
 
-import android.util.Log
-import com.linkedlist.linkellet.core.data.model.Auth
 import com.linkedlist.linkellet.core.data.model.Auth.*
 import com.linkedlist.linkellet.core.data.source.remote.AuthRemoteDataSource
 import kotlinx.coroutines.flow.Flow
@@ -14,15 +12,13 @@ class AuthRepositoryImpl @Inject constructor(
     override fun signUp(): Flow<Result<Boolean>> = flow {
         authRemoteDataSource.signUp()
             .onFailure {
-                throw it
+                emit(Result.failure(it))
             }.onSuccess {
-                when(it){
+                when (it) {
                     SIGNED_UP -> emit(Result.success(true))
                     ALREADY_SIGNED_UP -> emit(Result.success(true))
                     FAILED -> emit(Result.success(false))
                 }
-
             }
     }
-
 }

--- a/core/data/src/main/java/com/linkedlist/linkellet/core/data/source/remote/AuthRemoteDataSourceImpl.kt
+++ b/core/data/src/main/java/com/linkedlist/linkellet/core/data/source/remote/AuthRemoteDataSourceImpl.kt
@@ -30,6 +30,8 @@ class AuthRemoteDataSourceImpl @Inject constructor(
                 else Result.failure(Exception())
             }
         }catch (e: Exception){
+            println("d아아악")
+            e.printStackTrace()
             Result.failure(e)
         }
     }

--- a/feature/home/src/main/java/com/linkedlist/linkllet/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/linkedlist/linkllet/feature/home/HomeScreen.kt
@@ -31,6 +31,7 @@ import com.linkedlist.linkllet.core.designsystem.icon.lnkicon.Settings
 import com.linkedlist.linkllet.core.ui.LnkAppBar
 import com.linkedlist.linkllet.core.ui.LnkFloatingActionButton
 import com.linkedlist.linkllet.core.ui.LnkScrollableFolder
+import kotlinx.coroutines.flow.collect
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -39,11 +40,19 @@ internal fun HomeScreen(
     navigateToAddLink: () -> Unit,
     navigateToAddEditFolder: () -> Unit,
     navigateToLinks: (Long,String) -> Unit,
+    onShowSnackbar: suspend (String) -> Boolean,
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
     LaunchedEffect(Unit) {
         viewModel.fetchFolders()
+
+        viewModel.eventsFlow.collect {
+            when(it) {
+                is Event.Error -> onShowSnackbar(it.message)
+                else -> {}
+            }
+        }
     }
 
     Scaffold(
@@ -110,6 +119,7 @@ fun HomeScreenPreview() {
     HomeScreen(
         navigateToAddLink = {},
         navigateToAddEditFolder = {},
-        navigateToLinks = {_,_ ->}
+        navigateToLinks = {_,_ ->},
+        onShowSnackbar = {_ -> true },
     )
 }

--- a/feature/home/src/main/java/com/linkedlist/linkllet/feature/home/folder/AddEditFolderViewModel.kt
+++ b/feature/home/src/main/java/com/linkedlist/linkllet/feature/home/folder/AddEditFolderViewModel.kt
@@ -56,8 +56,8 @@ class AddEditFolderViewModel @Inject constructor(
         viewModelScope.launch {
             linkRepository.addFolder(uiState.value.folderName).collect { result ->
                 result.onSuccess {
-                    _eventsFlow.emit(Event.ShowToast("폴더가 추가되었어요"))
                     _eventsFlow.emit(Event.CloseScreen)
+                    _eventsFlow.emit(Event.ShowToast("폴더가 추가되었어요"))
                 }
             }
         }

--- a/feature/home/src/main/java/com/linkedlist/linkllet/feature/home/folder/AddEditFolderViewModel.kt
+++ b/feature/home/src/main/java/com/linkedlist/linkllet/feature/home/folder/AddEditFolderViewModel.kt
@@ -58,6 +58,8 @@ class AddEditFolderViewModel @Inject constructor(
                 result.onSuccess {
                     _eventsFlow.emit(Event.CloseScreen)
                     _eventsFlow.emit(Event.ShowToast("폴더가 추가되었어요"))
+                }.onFailure {
+                    _eventsFlow.emit(Event.ShowToast("폴더 저장에 실패했어요"))
                 }
             }
         }

--- a/feature/home/src/main/java/com/linkedlist/linkllet/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/linkedlist/linkllet/feature/home/navigation/HomeNavigation.kt
@@ -16,12 +16,14 @@ fun NavGraphBuilder.Home(
     navigateAddLink: () -> Unit,
     navigateToAddEdit: () -> Unit,
     navigateToLinks: (Long,String) -> Unit,
+    onShowSnackbar: suspend (String) -> Boolean,
 ) {
     composable(route = homeRoute) {
         HomeScreen(
             navigateToAddLink = navigateAddLink,
             navigateToAddEditFolder = navigateToAddEdit,
             navigateToLinks = navigateToLinks,
+            onShowSnackbar = onShowSnackbar,
         )
     }
 }


### PR DESCRIPTION
- 네트워크 미연결시 토스트 메시지를 띄워주고 이제 크래시 나지 않습니다.
- 폴더 제목 중복 및 빈 값에 대해서 메시지를 띄워줍니다

변경한 코드가 없는데 안 되던 코드가 신기하게 작동하네요...
400 에러시 서버에서 (중복)메시지를 내려주는데 당장 retorift에서 처리하기 어려운 것(성공, 실패시 데이터 타입이 다름) 같아서 일단 범용적인 메시지("폴더 저장에 실패했어요")를 띄웠습니다.