### PR TITLE
[refactor] 예외처리 방식 변경

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -16,10 +16,12 @@
             <option value="$PROJECT_DIR$/core/common" />
             <option value="$PROJECT_DIR$/core/data" />
             <option value="$PROJECT_DIR$/core/designsystem" />
+            <option value="$PROJECT_DIR$/core/login" />
             <option value="$PROJECT_DIR$/core/ui" />
             <option value="$PROJECT_DIR$/feature" />
             <option value="$PROJECT_DIR$/feature/home" />
             <option value="$PROJECT_DIR$/feature/link" />
+            <option value="$PROJECT_DIR$/feature/login" />
             <option value="$PROJECT_DIR$/feature/settings" />
           </set>
         </option>

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/LinkRemoteDataSource.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/LinkRemoteDataSource.kt
@@ -6,7 +6,7 @@ import com.linkedlist.linkllet.core.data.model.request.AddLinkRequest
 
 interface LinkRemoteDataSource {
 
-    suspend fun addFolder(name: String): Result<Unit>
+    suspend fun addFolder(name: String)
 
     suspend fun getFolders() : Result<List<Folder>>
 

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/LinkRemoteDataSourceImpl.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/LinkRemoteDataSourceImpl.kt
@@ -14,13 +14,12 @@ class LinkRemoteDataSourceImpl @Inject constructor(
     private val linkService: LinkService
 ) : LinkRemoteDataSource {
 
-    override suspend fun addFolder(name: String): Result<Unit> =
-        runCatching {
-            val response = linkService.addFolder(folder = AddFolderRequest(name = name))
-            if (!response.isSuccessful) throw RuntimeException(
-                response.errorBody().toMessage("폴더 저장에 실패했어요.")
-            )
-        }
+    override suspend fun addFolder(name: String) {
+        val response = linkService.addFolder(folder = AddFolderRequest(name = name))
+        if (!response.isSuccessful) throw RuntimeException(
+            response.errorBody().toMessage("폴더 저장에 실패했어요.")
+        )
+    }
 
     override suspend fun getFolders(): Result<List<Folder>> =
         runCatching {
@@ -42,7 +41,9 @@ class LinkRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun search(query: String): Result<List<Link>> = runCatching {
         val response = linkService.search(content = query)
-        if(!response.isSuccessful) throw RuntimeException(response.errorBody().toMessage("검색에 실패했어요."))
+        if (!response.isSuccessful) throw RuntimeException(
+            response.errorBody().toMessage("검색에 실패했어요.")
+        )
         response.body()?.articleList ?: emptyList()
     }
 

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/LinkRepository.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/LinkRepository.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface LinkRepository {
 
-    suspend fun addFolder(name: String): Flow<Result<Unit>>
+    fun addFolder(name: String): Flow<Unit>
 
     suspend fun getFolders() : Flow<Result<List<Folder>>>
 

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/LinkRepositoryImpl.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/LinkRepositoryImpl.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
 class LinkRepositoryImpl @Inject constructor(
     private val linkRemoteDataSource: LinkRemoteDataSource
 ) : LinkRepository {
-    override suspend fun addFolder(name: String): Flow<Result<Unit>> = flow {
+    override fun addFolder(name: String): Flow<Unit> = flow {
         emit(linkRemoteDataSource.addFolder(name = name))
     }
 

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/fake/FakeLinkRepository.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/fake/FakeLinkRepository.kt
@@ -10,22 +10,18 @@ class FakeLinkRepository : LinkRepository {
     var id = 1L
     private val folders = mutableListOf<Folder>()
 
-    override suspend fun addFolder(name: String): Flow<Result<Unit>> =
-        flow {
-            val res = runCatching {
-                folders.add(
-                    Folder(
-                        id = id++,
-                        name = name,
-                        type = "DEFAULT",
-                        size = 0
-                    )
-                )
-                Unit
-            }
+    override fun addFolder(name: String): Flow<Unit> = flow {
+        folders.add(
+            Folder(
+                id = id++,
+                name = name,
+                type = "DEFAULT",
+                size = 0
+            )
+        )
 
-            emit(res)
-        }
+        emit(Unit)
+    }
 
     override suspend fun getFolders(): Flow<Result<List<Folder>>> =
         flow {


### PR DESCRIPTION

## 변경사항
1. Flow를 반환할 경우 종단 연산자(Terminal operator)를 호출해야 flow가 시작된다. 즉, 종단 연산자를 실행하기 전까지는 suspend되지 않기 때문에 suspend 키워드 제거
2. Flow 도중 던져진 예외는 Flow<T>.catch(action) 에서 확인할 수 있다. runCatching의 역할을 Flow에서도 포함하고 있다고 생각되어 Result 제거
3. 실패했을 때 Throwable.message가 널일 때 처리 방식 변경