### PR TITLE
예외처리 방식 변경 2 (Result -> Flow)

### DIFF
--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/LinkRemoteDataSource.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/LinkRemoteDataSource.kt
@@ -8,24 +8,24 @@ interface LinkRemoteDataSource {
 
     suspend fun addFolder(name: String)
 
-    suspend fun getFolders() : Result<List<Folder>>
+    suspend fun getFolders(): List<Folder>
 
-    suspend fun getLinks(id : Long) : Result<List<Link>>
+    suspend fun getLinks(id: Long): List<Link>
 
-    suspend fun search(query: String): Result<List<Link>>
+    suspend fun search(query: String): List<Link>
 
     suspend fun addLink(
-        id : Long,
-        addLinkRequest : AddLinkRequest
-    ) : Result<Unit>
+        id: Long,
+        addLinkRequest: AddLinkRequest
+    )
 
     suspend fun deleteFolder(
-        id : Long
-    ) : Result<Unit>
+        id: Long
+    )
 
     suspend fun deleteLink(
-        id : Long,
-        articleId : Long
-    ) : Result<Unit>
+        id: Long,
+        articleId: Long
+    )
 
 }

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/LinkRemoteDataSourceImpl.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/LinkRemoteDataSourceImpl.kt
@@ -21,57 +21,53 @@ class LinkRemoteDataSourceImpl @Inject constructor(
         )
     }
 
-    override suspend fun getFolders(): Result<List<Folder>> =
-        runCatching {
-            val response = linkService.getFolders()
-            if (!response.isSuccessful) throw RuntimeException(
-                response.errorBody().toMessage("폴더 조회에 실패했어요.")
-            )
-            response.body()?.folderList ?: emptyList()
-        }
+    override suspend fun getFolders(): List<Folder> {
+        val response = linkService.getFolders()
+        if (!response.isSuccessful) throw RuntimeException(
+            response.errorBody().toMessage("폴더 조회에 실패했어요.")
+        )
+        return response.body()?.folderList ?: emptyList()
+    }
 
-    override suspend fun getLinks(id: Long): Result<List<Link>> =
-        runCatching {
-            val response = linkService.getLinks(id)
-            if (!response.isSuccessful) throw RuntimeException(
-                response.errorBody().toMessage("링크 조회에 실패했어요.")
-            )
-            response.body()?.articleList ?: emptyList()
-        }
+    override suspend fun getLinks(id: Long): List<Link> {
+        val response = linkService.getLinks(id)
+        if (!response.isSuccessful) throw RuntimeException(
+            response.errorBody().toMessage("링크 조회에 실패했어요.")
+        )
+        return response.body()?.articleList ?: emptyList()
+    }
 
-    override suspend fun search(query: String): Result<List<Link>> = runCatching {
+    override suspend fun search(query: String): List<Link> {
         val response = linkService.search(content = query)
         if (!response.isSuccessful) throw RuntimeException(
             response.errorBody().toMessage("검색에 실패했어요.")
         )
-        response.body()?.articleList ?: emptyList()
+        return response.body()?.articleList ?: emptyList()
     }
 
     override suspend fun addLink(
         id: Long,
         addLinkRequest: AddLinkRequest
-    ): Result<Unit> = runCatching {
+    ) {
         val response = linkService.addLink(id = id, addLinkRequest = addLinkRequest)
         if (!response.isSuccessful) throw RuntimeException(
             response.errorBody().toMessage("링크를 저장할 수 없어요.")
         )
     }
 
-    override suspend fun deleteFolder(id: Long): Result<Unit> =
-        runCatching {
-            val response = linkService.deleteFolder(id = id)
-            if (!response.isSuccessful) throw RuntimeException(
-                response.errorBody().toMessage("폴더를 삭제할 수 없어요.")
-            )
-        }
+    override suspend fun deleteFolder(id: Long) {
+        val response = linkService.deleteFolder(id = id)
+        if (!response.isSuccessful) throw RuntimeException(
+            response.errorBody().toMessage("폴더를 삭제할 수 없어요.")
+        )
+    }
 
-    override suspend fun deleteLink(id: Long, articleId: Long): Result<Unit> =
-        runCatching {
-            val response = linkService.deleteLink(id = id, articleId = articleId)
-            if (!response.isSuccessful) throw RuntimeException(
-                response.errorBody().toMessage("링크를 삭제할 수 없어요.")
-            )
-        }
+    override suspend fun deleteLink(id: Long, articleId: Long) {
+        val response = linkService.deleteLink(id = id, articleId = articleId)
+        if (!response.isSuccessful) throw RuntimeException(
+            response.errorBody().toMessage("링크를 삭제할 수 없어요.")
+        )
+    }
 
     private fun ResponseBody?.toMessage(defaultMessage: String): String {
         return try {

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/LinkRemoteDataSourceImpl.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/LinkRemoteDataSourceImpl.kt
@@ -22,27 +22,33 @@ class LinkRemoteDataSourceImpl @Inject constructor(
     }
 
     override suspend fun getFolders(): List<Folder> {
+        val errorMessage = "폴더 조회에 실패했어요."
+
         val response = linkService.getFolders()
         if (!response.isSuccessful) throw RuntimeException(
-            response.errorBody().toMessage("폴더 조회에 실패했어요.")
+            response.errorBody().toMessage(errorMessage)
         )
-        return response.body()?.folderList ?: emptyList()
+        return response.body()?.folderList ?: throw RuntimeException(errorMessage)
     }
 
     override suspend fun getLinks(id: Long): List<Link> {
+        val errorMessage = "링크 조회에 실패했어요."
+
         val response = linkService.getLinks(id)
         if (!response.isSuccessful) throw RuntimeException(
-            response.errorBody().toMessage("링크 조회에 실패했어요.")
+            response.errorBody().toMessage(errorMessage)
         )
-        return response.body()?.articleList ?: emptyList()
+        return response.body()?.articleList ?: throw RuntimeException(errorMessage)
     }
 
     override suspend fun search(query: String): List<Link> {
+        val errorMessage = "검색에 실패했어요."
+
         val response = linkService.search(content = query)
         if (!response.isSuccessful) throw RuntimeException(
-            response.errorBody().toMessage("검색에 실패했어요.")
+            response.errorBody().toMessage(errorMessage)
         )
-        return response.body()?.articleList ?: emptyList()
+        return response.body()?.articleList ?: throw RuntimeException(errorMessage)
     }
 
     override suspend fun addLink(

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/LinkRepository.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/LinkRepository.kt
@@ -8,24 +8,24 @@ interface LinkRepository {
 
     fun addFolder(name: String): Flow<Unit>
 
-    suspend fun getFolders() : Flow<Result<List<Folder>>>
+    fun getFolders(): Flow<List<Folder>>
 
-    suspend fun getLinks(id : Long) : Flow<Result<List<Link>>>
+    fun getLinks(id: Long): Flow<List<Link>>
 
-    suspend fun search(query: String): Flow<Result<List<Link>>>
+    fun search(query: String): Flow<List<Link>>
 
-    suspend fun addLink(
-        id : Long,
-        name : String,
-        url : String
-    ) : Flow<Result<Unit>>
+    fun addLink(
+        id: Long,
+        name: String,
+        url: String
+    ): Flow<Unit>
 
-    suspend fun deleteFolder(
-        id : Long
-    ) : Flow<Result<Unit>>
+    fun deleteFolder(
+        id: Long
+    ): Flow<Unit>
 
-    suspend fun deleteLink(
-        id : Long,
-        articleId : Long
-    ) : Flow<Result<Unit>>
+    fun deleteLink(
+        id: Long,
+        articleId: Long
+    ): Flow<Unit>
 }

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/LinkRepositoryImpl.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/LinkRepositoryImpl.kt
@@ -15,19 +15,19 @@ class LinkRepositoryImpl @Inject constructor(
         emit(linkRemoteDataSource.addFolder(name = name))
     }
 
-    override suspend fun getFolders(): Flow<Result<List<Folder>>> = flow {
+    override fun getFolders(): Flow<List<Folder>> = flow {
         emit(linkRemoteDataSource.getFolders())
     }
 
-    override suspend fun getLinks(id: Long): Flow<Result<List<Link>>> = flow {
+    override fun getLinks(id: Long): Flow<List<Link>> = flow {
         emit(linkRemoteDataSource.getLinks(id))
     }
 
-    override suspend fun search(query: String): Flow<Result<List<Link>>> = flow {
+    override fun search(query: String): Flow<List<Link>> = flow {
         emit(linkRemoteDataSource.search(query))
     }
 
-    override suspend fun addLink(id: Long, name: String, url: String): Flow<Result<Unit>> = flow {
+    override fun addLink(id: Long, name: String, url: String): Flow<Unit> = flow {
         emit(
             linkRemoteDataSource.addLink(
                 id = id,
@@ -39,11 +39,11 @@ class LinkRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun deleteFolder(id: Long): Flow<Result<Unit>> = flow {
+    override fun deleteFolder(id: Long): Flow<Unit> = flow {
         emit(linkRemoteDataSource.deleteFolder(id = id))
     }
 
-    override suspend fun deleteLink(id: Long, articleId: Long): Flow<Result<Unit>> = flow {
+    override fun deleteLink(id: Long, articleId: Long): Flow<Unit> = flow {
         emit(
             linkRemoteDataSource.deleteLink(
                 id = id,

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/fake/FakeLinkRepository.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/fake/FakeLinkRepository.kt
@@ -23,28 +23,28 @@ class FakeLinkRepository : LinkRepository {
         emit(Unit)
     }
 
-    override suspend fun getFolders(): Flow<Result<List<Folder>>> =
+    override fun getFolders(): Flow<List<Folder>> =
         flow {
-            emit(Result.success(folders))
+            emit(folders)
         }
 
-    override suspend fun getLinks(id: Long): Flow<Result<List<Link>>> {
+    override fun getLinks(id: Long): Flow<List<Link>> {
         TODO("Not yet implemented")
     }
 
-    override suspend fun search(query: String): Flow<Result<List<Link>>> {
+    override fun search(query: String): Flow<List<Link>> {
         TODO("Not yet implemented")
     }
 
-    override suspend fun addLink(id: Long, name: String, url: String): Flow<Result<Unit>> {
+    override fun addLink(id: Long, name: String, url: String): Flow<Unit> {
         TODO("Not yet implemented")
     }
 
-    override suspend fun deleteFolder(id: Long): Flow<Result<Unit>> {
+    override fun deleteFolder(id: Long): Flow<Unit> {
         TODO("Not yet implemented")
     }
 
-    override suspend fun deleteLink(id: Long, articleId: Long): Flow<Result<Unit>> {
+    override fun deleteLink(id: Long, articleId: Long): Flow<Unit> {
         TODO("Not yet implemented")
     }
 }

--- a/feature/home/src/main/java/com/linkedlist/linkllet/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/linkedlist/linkllet/feature/home/HomeViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
@@ -61,13 +62,9 @@ class HomeViewModel @Inject constructor(
             }
             .onEach { folders ->
                 _uiState.update { it.copy(folders = folders) }
-                _loading.value = false
             }
-            .catch {
-                _loading.value = false
-                _error.value = false
-            }
-            .catch { _loading.value = false }
+            .catch { _error.value = true }
+            .onCompletion { _loading.value = false }
             .launchIn(viewModelScope)
     }
 

--- a/feature/home/src/main/java/com/linkedlist/linkllet/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/linkedlist/linkllet/feature/home/HomeViewModel.kt
@@ -12,9 +12,12 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
-import java.net.ConnectException
 import javax.inject.Inject
 
 sealed class Event {
@@ -44,27 +47,28 @@ class HomeViewModel @Inject constructor(
     val eventsFlow: SharedFlow<Event> = _eventsFlow.asSharedFlow()
 
     fun fetchFolders() {
-        viewModelScope.launch {
-            _loading.value = true
-            linkRepository.getFolders().collect { result ->
-                result.mapCatching { folders ->
-                    folders.map {
-                        FolderModel(
-                            folderId = it.id,
-                            name = it.name,
-                            totalItems = it.size,
-                            type = it.type
-                        )
-                    }
-                }.onSuccess { folders ->
-                    _uiState.update { it.copy(folders = folders) }
-                    _loading.value = false
-                }.onFailure {
-                    _loading.value = false
-                    _error.value = false
+        linkRepository.getFolders()
+            .onStart { _loading.value = true }
+            .map { folders ->
+                folders.map {
+                    FolderModel(
+                        folderId = it.id,
+                        name = it.name,
+                        totalItems = it.size,
+                        type = it.type
+                    )
                 }
             }
-        }
+            .onEach { folders ->
+                _uiState.update { it.copy(folders = folders) }
+                _loading.value = false
+            }
+            .catch {
+                _loading.value = false
+                _error.value = false
+            }
+            .catch { _loading.value = false }
+            .launchIn(viewModelScope)
     }
 
     fun expandCard(expanded: Boolean) {

--- a/feature/link/src/main/java/com/linkedlist/linkllet/feature/link/addeditlink/AddEditLinkViewModel.kt
+++ b/feature/link/src/main/java/com/linkedlist/linkllet/feature/link/addeditlink/AddEditLinkViewModel.kt
@@ -137,16 +137,14 @@ class AddEditLinkViewModel @Inject constructor(
                     isLinkSaved = true
                 )
             }
-        }
-            .catch {
-                if (it.message == null) _error.emit(AddEditLinkError.NETWORK_ERROR)
-                else {
-                    it.message?.let { message ->
-                        _snackbarState.emit(message)
-                    }
+        }.catch {
+            if (it.message == null) _error.emit(AddEditLinkError.NETWORK_ERROR)
+            else {
+                it.message?.let { message ->
+                    _snackbarState.emit(message)
                 }
             }
-            .launchIn(viewModelScope)
+        }.launchIn(viewModelScope)
     }
 
 

--- a/feature/link/src/main/java/com/linkedlist/linkllet/feature/link/addeditlink/AddEditLinkViewModel.kt
+++ b/feature/link/src/main/java/com/linkedlist/linkllet/feature/link/addeditlink/AddEditLinkViewModel.kt
@@ -65,6 +65,8 @@ class AddEditLinkViewModel @Inject constructor(
     )
     val uiState: StateFlow<AddEditLinkUiState> = _uiState.asStateFlow()
 
+    private val urlValidator = UrlValidator()
+
     fun getChangedInputs() : Boolean {
         return uiState.value.title.trim().isNotBlank() || uiState.value.link.trim().isNotBlank()
                 || if(folderId != -1L) uiState.value.folders.find { it.isSelected }?.id != folderId
@@ -197,21 +199,12 @@ class AddEditLinkViewModel @Inject constructor(
 
     fun getValidUrl() : String? {
         val sharedUrl = savedStateHandle.getStateFlow(NavController.KEY_DEEP_LINK_INTENT,Intent()).value.getStringExtra(Intent.EXTRA_TEXT) ?: return null
-        return if(isValidUrl(sharedUrl)){
+        return if (urlValidator.validateUrl(sharedUrl)) {
             sharedUrl
-        }else {
+        } else {
             _error.value = AddEditLinkError.NOT_VALID_URL
             null
         }
-    }
-
-    private fun isValidUrl(url : String ) : Boolean {
-        val pattern = Pattern.compile(
-            "^(https?|ftp)://[\\w-]+(\\.[\\w-]+)+([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])?\$",
-            Pattern.CASE_INSENSITIVE
-        )
-        val matcher = pattern.matcher(url)
-        return matcher.matches()
     }
 }
 

--- a/feature/link/src/main/java/com/linkedlist/linkllet/feature/link/addeditlink/AddEditLinkViewModel.kt
+++ b/feature/link/src/main/java/com/linkedlist/linkllet/feature/link/addeditlink/AddEditLinkViewModel.kt
@@ -146,11 +146,7 @@ class AddEditLinkViewModel @Inject constructor(
             }
         }.catch {
             if (it.message == null) _error.emit(AddEditLinkError.NETWORK_ERROR)
-            else {
-                it.message?.let { message ->
-                    _snackbarState.emit(message)
-                }
-            }
+            else _snackbarState.emit(it.message ?: "에러가 발생했어요.")
         }.onCompletion {
             addLinkJob = null
         }.launchIn(viewModelScope)
@@ -181,8 +177,8 @@ class AddEditLinkViewModel @Inject constructor(
     }
 
     fun updateFolder(title: String) {
-        _uiState.update {
-            it.copy(folders = it.folders.map {
+        _uiState.update { state ->
+            state.copy(folders = state.folders.map {
                 if (it.name == title) it.copy(isSelected = true)
                 else it.copy(isSelected = false)
             })

--- a/feature/link/src/main/java/com/linkedlist/linkllet/feature/link/addeditlink/AddEditLinkViewModel.kt
+++ b/feature/link/src/main/java/com/linkedlist/linkllet/feature/link/addeditlink/AddEditLinkViewModel.kt
@@ -105,7 +105,7 @@ class AddEditLinkViewModel @Inject constructor(
                     .catch {
                         _error.emit(AddEditLinkError.NETWORK_ERROR)
                     }.collect {
-                        it.onSuccess {
+                        try {
                             _uiState.emit(
                                 uiState.value.copy(
                                     folders = it.map {
@@ -117,10 +117,9 @@ class AddEditLinkViewModel @Inject constructor(
                                     }
                                 )
                             )
-                        }.onFailure {
+                        } catch (e: Throwable) {
                             _error.emit(AddEditLinkError.NETWORK_ERROR)
                         }
-
                     }
             }catch (e: Exception){
                 _error.emit(AddEditLinkError.NETWORK_ERROR)
@@ -140,19 +139,18 @@ class AddEditLinkViewModel @Inject constructor(
                     ).catch {
                         _error.emit(AddEditLinkError.NETWORK_ERROR)
                     }.collect {
-                        it.onSuccess {
+                        try {
                             _uiState.emit(uiState.value.copy(
                                 isLinkSaved = true
                             ))
-                        }.onFailure {
-                            if(it.message == null) _error.emit(AddEditLinkError.NETWORK_ERROR)
+                        } catch (e: Throwable) {
+                            if(e.message == null) _error.emit(AddEditLinkError.NETWORK_ERROR)
                             else {
-                                it.message?.let {
+                                e.message?.let {
                                     _snackbarState.emit(it)
                                 }
                             }
                         }
-
                     }
                 }else {
                     _snackbarState.emit("정보를 입력해주세요.")

--- a/feature/link/src/main/java/com/linkedlist/linkllet/feature/link/addeditlink/UrlValidator.kt
+++ b/feature/link/src/main/java/com/linkedlist/linkllet/feature/link/addeditlink/UrlValidator.kt
@@ -1,0 +1,14 @@
+package com.linkedlist.linkllet.feature.link.addeditlink
+
+import java.util.regex.Pattern
+
+class UrlValidator {
+    fun validateUrl(url: String): Boolean {
+        val pattern = Pattern.compile(
+            "^(https?|ftp)://[\\w-]+(\\.[\\w-]+)+([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])?\$",
+            Pattern.CASE_INSENSITIVE
+        )
+        val matcher = pattern.matcher(url)
+        return matcher.matches()
+    }
+}

--- a/feature/link/src/main/java/com/linkedlist/linkllet/feature/link/links/LinksViewModel.kt
+++ b/feature/link/src/main/java/com/linkedlist/linkllet/feature/link/links/LinksViewModel.kt
@@ -29,8 +29,8 @@ sealed class Event {
 }
 
 data class LinksUiState(
-    val folderTitle : String = "",
-    val folderType : FolderType,
+    val folderTitle: String = "",
+    val folderType: FolderType,
     val links: List<LinkUiModel> = emptyList(),
     val isLoading: Boolean = false
 )
@@ -68,17 +68,17 @@ class LinksViewModel @Inject constructor(
             folderId?.let {
                 linkRepository.getLinks(
                     id = it
-                ).collect { result ->
-                    result.onSuccess {
+                ).collect { links ->
+                    try {
                         _uiState.emit(
                             uiState.value.copy(
-                                links = it.map { link ->
+                                links = links.map { link ->
                                     link.toUiModel()
                                 }
                             )
                         )
-                    }.onFailure {
-                        it.message?.let { message ->
+                    } catch (e: Throwable) {
+                        e.message?.let { message ->
                             _eventsFlow.emit(Event.Error(message))
                         }
                     }
@@ -92,11 +92,11 @@ class LinksViewModel @Inject constructor(
             folderId?.let {
                 linkRepository.deleteFolder(
                     id = it
-                ).collect { result ->
-                    result.onSuccess {
+                ).collect {
+                    try {
                         _eventsFlow.emit(Event.FolderDeleted)
-                    }.onFailure {
-                        it.message?.let { message ->
+                    } catch (e: Throwable) {
+                        e.message?.let { message ->
                             _eventsFlow.emit(Event.Error(message))
                         }
                     }
@@ -105,18 +105,18 @@ class LinksViewModel @Inject constructor(
         }
     }
 
-    fun deleteLink(linkId : Long) {
+    fun deleteLink(linkId: Long) {
         viewModelScope.launch {
             folderId?.let {
                 linkRepository.deleteLink(
                     id = it,
                     articleId = linkId
-                ).collect { result ->
-                    result.onSuccess {
+                ).collect {
+                    try {
                         fetchLinks()
                         _eventsFlow.emit(Event.LinkDeleted)
-                    }.onFailure {
-                        it.message?.let { message ->
+                    } catch (e: Throwable) {
+                        e.message?.let { message ->
                             _eventsFlow.emit(Event.Error(message))
                         }
                     }
@@ -125,7 +125,7 @@ class LinksViewModel @Inject constructor(
         }
     }
 
-    fun selectLink(url : String) {
+    fun selectLink(url: String) {
         viewModelScope.launch {
             _eventsFlow.emit(Event.ShowLink(url))
         }

--- a/feature/link/src/test/java/com/linkedlist/linkllet/feature/link/addeditlink/UrlValidatorTest.kt
+++ b/feature/link/src/test/java/com/linkedlist/linkllet/feature/link/addeditlink/UrlValidatorTest.kt
@@ -1,0 +1,41 @@
+package com.linkedlist.linkllet.feature.link.addeditlink
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class UrlValidatorTest {
+
+    private val urlValidator = UrlValidator()
+
+    @Test
+    fun `유효한 Url이 들어오면 true를 반환한다`() {
+        // given
+        val urls = listOf(
+            "https://www.naver.com",
+            "https://github.com/Nexters/Linkllet-Android",
+            "https://algosketch.tistory.com/176"
+        )
+
+        // when & then
+        urls.forEach {
+            val result = urlValidator.validateUrl(it)
+            assertTrue(result)
+        }
+    }
+
+    @Test
+    fun `유효하지 않은 Url이 들어오면 false를 반환한다`() {
+        // given
+        val urls = listOf(
+            "https://www.naver.",
+            "ttps://www.naver.",
+            "https:/www.naver.com",
+        )
+
+        // when & then
+        urls.forEach {
+            val result = urlValidator.validateUrl(it)
+            assertFalse(result)
+        }
+    }
+}


### PR DESCRIPTION
LinkRepository 부분 예외처리 로직 변경

- suspend 제거
- Flow<Result<T>> 에서 Flow<T>으로 변경
- 기존 try-catch 제거
- folderId가 null일 경우 : ealry return
- 결과가 null일 때와 emptyList일 때와 구분하기 위해 null이면 throw

추가로 예외 리팩터링은 아니지만 다음 코드도 변경했어

- 더블 클릭 방지
- Url 유효성 검사 클래스 추출

변경된 코드가 좀 돼서 나도 다시 한 번 확인해봐야 할 듯!