### PR TITLE
Result 래핑 제거, 중복 클릭 처리

### DIFF
--- a/app/src/main/java/com/linkedlist/linkllet/MainViewModel.kt
+++ b/app/src/main/java/com/linkedlist/linkllet/MainViewModel.kt
@@ -13,7 +13,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -96,17 +99,15 @@ class MainViewModel @Inject constructor(
             }
     }
 
-    private fun signUp(){
-        viewModelScope.launch {
-            authRepository.signUp()
-                .collect {
-                    it.onSuccess {
-                        _uiState.emit(MainUiState.LoginSuccess)
-                    }.onFailure {
-                        _uiState.emit(MainUiState.LoginFailed)
-                    }
-                }
-        }
+    private fun signUp() {
+        authRepository.signUp()
+            .onEach {
+                _uiState.emit(MainUiState.LoginSuccess)
+            }
+            .catch {
+                _uiState.emit(MainUiState.LoginFailed)
+            }
+            .launchIn(viewModelScope)
     }
 
     fun navigateToAddEditLink() {

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/AuthRemoteDataSource.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/AuthRemoteDataSource.kt
@@ -4,5 +4,5 @@ import com.linkedlist.linkllet.core.data.model.Auth
 
 interface AuthRemoteDataSource {
     suspend fun signUp(): Result<Auth>
-    suspend fun addFeedback(content: String): Result<Unit>
+    suspend fun addFeedback(content: String)
 }

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/AuthRemoteDataSource.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/AuthRemoteDataSource.kt
@@ -3,6 +3,6 @@ package com.linkedlist.linkllet.core.data.remote
 import com.linkedlist.linkllet.core.data.model.Auth
 
 interface AuthRemoteDataSource {
-    suspend fun signUp(): Result<Auth>
+    suspend fun signUp(): Auth
     suspend fun addFeedback(content: String)
 }

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/AuthRemoteDataSourceImpl.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/AuthRemoteDataSourceImpl.kt
@@ -17,14 +17,14 @@ class AuthRemoteDataSourceImpl @Inject constructor(
 ) : AuthRemoteDataSource {
 
     @SuppressLint("HardwareIds")
-    override suspend fun signUp(): Result<Auth> = runCatching {
+    override suspend fun signUp(): Auth {
         val response = authService.signUp(
             SignUpRequest(
                 deviceId = loginManager.deviceId
             )
         )
 
-        when {
+        return when {
             response.isSuccessful -> Auth.SIGNED_UP
             response.code() == 409 -> Auth.ALREADY_SIGNED_UP
             else -> throw RuntimeException("회원가입에 실패했어요.")

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/AuthRemoteDataSourceImpl.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/remote/AuthRemoteDataSourceImpl.kt
@@ -31,7 +31,7 @@ class AuthRemoteDataSourceImpl @Inject constructor(
         }
     }
 
-    override suspend fun addFeedback(content: String): Result<Unit> = runCatching {
+    override suspend fun addFeedback(content: String) {
         val response = authService.addFeedback(AddFeedbackRequest(feedback = content))
         if(!response.isSuccessful) throw RuntimeException("피드백 전송에 실패했어요.")
     }

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/AuthRepository.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/AuthRepository.kt
@@ -4,6 +4,6 @@ import kotlinx.coroutines.flow.Flow
 
 interface AuthRepository {
 
-    fun signUp(): Flow<Result<Boolean>>
+    fun signUp(): Flow<Boolean>
     fun addFeedback(content: String): Flow<Unit>
 }

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/AuthRepository.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/AuthRepository.kt
@@ -5,5 +5,5 @@ import kotlinx.coroutines.flow.Flow
 interface AuthRepository {
 
     fun signUp(): Flow<Result<Boolean>>
-    fun addFeedback(content: String): Flow<Result<Unit>>
+    fun addFeedback(content: String): Flow<Unit>
 }

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/AuthRepositoryImpl.kt
@@ -11,15 +11,11 @@ class AuthRepositoryImpl @Inject constructor(
     private val authRemoteDataSource: AuthRemoteDataSource
 ) : AuthRepository {
 
-    override fun signUp(): Flow<Result<Boolean>> = flow {
-        emit(authRemoteDataSource.signUp().mapCatching { auth ->
-            when (auth) {
-                SIGNED_UP, ALREADY_SIGNED_UP -> {
-                    true
-                }
-                else -> false
-            }
-        })
+    override fun signUp(): Flow<Boolean> = flow {
+        val response = authRemoteDataSource.signUp()
+        val successfulResponses = listOf(SIGNED_UP, ALREADY_SIGNED_UP)
+
+        emit(response in successfulResponses)
     }
 
     override fun addFeedback(content: String): Flow<Unit> = flow {

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/AuthRepositoryImpl.kt
@@ -22,7 +22,8 @@ class AuthRepositoryImpl @Inject constructor(
         })
     }
 
-    override fun addFeedback(content: String): Flow<Result<Unit>> = flow {
-        emit(authRemoteDataSource.addFeedback(content))
+    override fun addFeedback(content: String): Flow<Unit> = flow {
+        val response = authRemoteDataSource.addFeedback(content)
+        emit(response)
     }
 }

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/fake/FakeAuthRepository.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/fake/FakeAuthRepository.kt
@@ -9,7 +9,7 @@ class FakeAuthRepository : AuthRepository {
         TODO("Not yet implemented")
     }
 
-    override fun addFeedback(content: String): Flow<Result<Unit>> {
+    override fun addFeedback(content: String): Flow<Unit> {
         TODO("Not yet implemented")
     }
 }

--- a/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/fake/FakeAuthRepository.kt
+++ b/core/data/src/main/java/com/linkedlist/linkllet/core/data/repository/fake/FakeAuthRepository.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 
 class FakeAuthRepository : AuthRepository {
 
-    override fun signUp(): Flow<Result<Boolean>> {
+    override fun signUp(): Flow<Boolean> {
         TODO("Not yet implemented")
     }
 

--- a/feature/settings/src/main/java/linkedlist/linkllet/feature/settings/FeedbackViewModel.kt
+++ b/feature/settings/src/main/java/linkedlist/linkllet/feature/settings/FeedbackViewModel.kt
@@ -4,12 +4,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.linkedlist.linkllet.core.data.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -28,15 +30,20 @@ class FeedbackViewModel @Inject constructor(
     private val _eventsFlow = MutableSharedFlow<FeedbackEvent>()
     val eventsFlow: SharedFlow<FeedbackEvent> = _eventsFlow.asSharedFlow()
 
+    private var postFeedbackJob: Job? = null
+
     fun updateContent(newContent: String) {
         _content.value = newContent
     }
 
     fun sendFeedback() {
-        authRepository.addFeedback(content = content.value)
+        if(postFeedbackJob != null) return
+
+        postFeedbackJob = authRepository.addFeedback(content = content.value)
             .onEach {
                 _eventsFlow.emit(FeedbackEvent.CloseScreen)
             }
+            .onCompletion { postFeedbackJob = null }
             .launchIn(viewModelScope)
     }
 }

--- a/feature/settings/src/main/java/linkedlist/linkllet/feature/settings/FeedbackViewModel.kt
+++ b/feature/settings/src/main/java/linkedlist/linkllet/feature/settings/FeedbackViewModel.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -31,13 +33,10 @@ class FeedbackViewModel @Inject constructor(
     }
 
     fun sendFeedback() {
-        viewModelScope.launch {
-            authRepository.addFeedback(content = content.value)
-                .collect { result ->
-                    result.onSuccess {
-                        _eventsFlow.emit(FeedbackEvent.CloseScreen)
-                    }
-                }
-        }
+        authRepository.addFeedback(content = content.value)
+            .onEach {
+                _eventsFlow.emit(FeedbackEvent.CloseScreen)
+            }
+            .launchIn(viewModelScope)
     }
 }


### PR DESCRIPTION
- Result의 runCatching -> Flow의 catch로 변경
- 피드백 전송 연속 클릭 방지 로직 추가